### PR TITLE
docs: track catch-up tasks and refresh GPU sweep guidance

### DIFF
--- a/README-G1MvP.md
+++ b/README-G1MvP.md
@@ -7,12 +7,12 @@ This repository provisions a local, open-source AI stack with Docker Compose. Ev
 - Ollama hosts and serves local LLMs, Open WebUI provides the chat UI, and Qdrant offers vector search for retrieval-augmented workflows.
 
 ## Directory Layout
-- `infra/compose/` – primary `docker-compose.yml` plus future overrides.
-- `scripts/` – PowerShell helpers (`compose.ps1`, `model.ps1`, `context-sweep.ps1`, `eval-context.ps1`).
-- `modelfiles/` – custom Ollama Modelfiles tracked in git.
-- `data/`, `models/` – persistent volumes and caches (ignored by git).
-- `docs/` – architecture notes, release reports, and context evaluation outputs.
-- `src/`, `tests/` – application code and mirrored test suites (add as needed).
+- `infra/compose/`  primary `docker-compose.yml` plus future overrides.
+- `scripts/`  PowerShell helpers (`compose.ps1`, `model.ps1`, `context-sweep.ps1`, `eval-context.ps1`).
+- `modelfiles/`  custom Ollama Modelfiles tracked in git.
+- `data/`, `models/`  persistent volumes and caches (ignored by git).
+- `docs/`  architecture notes, release reports, and context evaluation outputs.
+- `src/`, `tests/`  application code and mirrored test suites (add as needed).
 
 ## Prerequisites
 - Windows 11 (WSL2 optional) with administrator rights.
@@ -25,11 +25,11 @@ This repository provisions a local, open-source AI stack with Docker Compose. Ev
 3. Open http://localhost:3000 for Open WebUI (talks to Ollama at http://localhost:11434 and Qdrant at http://localhost:6333).
 
 ## Operations & Validation
-- `./scripts/compose.ps1 up|down|restart|logs` – manage the compose services.
-- `docker compose -f infra/compose/docker-compose.yml up -d` – direct compose invocation for automation.
-- `./scripts/model.ps1 list|pull|create-all` – manage base and custom Ollama models.
-- `./scripts/context-sweep.ps1 -CpuOnly -Safe -WriteReport` – integration sweep that emits `docs/CONTEXT_RESULTS_*.md`.
-- `./scripts/eval-context.ps1 -Model llama31-8b-c8k -TokensTarget 6000` – targeted evaluation run.
+- `./scripts/compose.ps1 up|down|restart|logs`  manage the compose services.
+- `docker compose -f infra/compose/docker-compose.yml up -d`  direct compose invocation for automation.
+- `./scripts/model.ps1 list|pull|create-all`  manage base and custom Ollama models.
+- `./scripts/context-sweep.ps1 -Safe -WriteReport`  integration sweep that captures GPU validation evidence (append `-CpuOnly` only when a CUDA-capable device is unavailable) and emits `docs/CONTEXT_RESULTS_*.md`.
+- `./scripts/eval-context.ps1 -Model llama31-8b-c8k -TokensTarget 6000`  targeted evaluation run.
 
 ## Maintenance Tips
 - Keep `.env` in sync with `.env.example`; never commit secrets.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For automation pipelines that must avoid prompts, call `./scripts/bootstrap.ps1 
 ## Validation & Health Checks
 - Generate a host environment fingerprint with `./scripts/bootstrap.ps1 -Report` (writes `docs/ENVIRONMENT.md` **and** archives the same output under `docs/evidence/environment/`). The report now checks for `curl`, `pytest`, `nvidia-smi`, and `ollama` in addition to the original tooling list.
 - Launch the interactive diagnostics menu explicitly with `./scripts/bootstrap.ps1 -Menu`. The menu exposes GPU evaluation, host checks, and the imported Clean repository utilities.
-- Run a guarded evaluation sweep: `./scripts/context-sweep.ps1 -CpuOnly -Safe -WriteReport` (outputs `docs/CONTEXT_RESULTS_*.md`).
+- Run a guarded evaluation sweep with GPU validation: `./scripts/context-sweep.ps1 -Safe -WriteReport` (add `-CpuOnly` only when CUDA resources are unavailable to keep evidence flowing into `docs/CONTEXT_RESULTS_*.md`).
 - Tail combined service logs: `./scripts/compose.ps1 logs`.
 - Run automated smoke tests locally with `pip install -r requirements-dev.txt && pytest`. These checks parse `infra/compose/docker-compose.yml`, verify Modelfiles, and validate `.env.example` defaults. The same suite executes in CI via `.github/workflows/smoke-tests.yml`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+# Catch-Up Priorities
+
+- [ ] Run and archive a GPU context sweep using `./scripts/context-sweep.ps1 -Safe -WriteReport` so CUDA paths are validated and the markdown report lands under `docs/`.
+- [ ] Extend smoke automation with runtime health probes and coverage tooling, ensuring CI emits evidence under `docs/evidence/` for each run.
+- [ ] Stabilise operator tooling by rerunning `./scripts/bootstrap.ps1 -PromptSecrets`, confirming PowerShell 7+, Docker, Git, and other dependencies exist, then recreating context models.
+- [ ] Document and automate backup and recovery for `data/open-webui` and `data/qdrant`, capturing the procedure and test restores in `docs/`.
+- [ ] Enrich architecture and monitoring documentation (e.g., `docs/ARCHITECTURE.md`) with diagrams and telemetry conventions to guide onboarding and observability work.

--- a/docs/RELEASE_v2025-09-16.md
+++ b/docs/RELEASE_v2025-09-16.md
@@ -7,7 +7,7 @@
 
 ## Validation & Coverage Overview
 - Manual Checks: Open WebUI reachable at `http://localhost:3000` with responsive chat flows; Ollama models execute on available GPUs via `NVIDIA_VISIBLE_DEVICES=all`.
-- Automation: No unit or integration test suites currently configured; coverage tooling is absent. Context sweep scripts are prepared but not executed during this release (recommended next run: `./scripts/context-sweep.ps1 -CpuOnly -Safe -WriteReport`).
+- Automation: No unit or integration test suites currently configured; coverage tooling is absent. Context sweep scripts are prepared but not executed during this release (run `./scripts/context-sweep.ps1 -Safe -WriteReport` to capture the overdue GPU evidence, falling back to `-CpuOnly` only when CUDA is unavailable).
 - Risk Notes: Absence of automated regression tests; rely on manual smoke verification and compose health checks (`docker compose -f infra/compose/docker-compose.yml ps`).
 
 ## Issues & Resolutions
@@ -26,7 +26,7 @@
 ## Configuration Snapshot
 - Environment Variables: ports `WEBUI_PORT=3000`, `OLLAMA_PORT=11434`, `QDRANT_PORT=6333`; storage paths `MODELS_DIR=./models`, `DATA_DIR=./data`; authentication flag `OPENWEBUI_AUTH=false` (toggle before exposing beyond localhost).
 - Compose Overrides: GPU access declared by `gpus: all` and `NVIDIA_DRIVER_CAPABILITIES=compute,utility` for the Ollama service.
-- Network Bindings: Localhost endpoints — WebUI `3000/tcp`, Ollama `11434/tcp`, Qdrant `6333/tcp`.
+- Network Bindings: Localhost endpoints  WebUI `3000/tcp`, Ollama `11434/tcp`, Qdrant `6333/tcp`.
 - Persistence: Model cache under `models/` (git-ignored), service state under `data/` with directory-per-service segmentation.
 
 ## Operational Checklist

--- a/docs/STACK_STATUS_2025-09-16.md
+++ b/docs/STACK_STATUS_2025-09-16.md
@@ -29,4 +29,4 @@
 2. Export the resulting `OLLAMA_API_KEY` (dummy or custom) before launching the Codex CLI so requests authenticate cleanly.
 3. Start the stack with `./scripts/compose.ps1 up` and verify service health via `./scripts/compose.ps1 logs`.
 4. Register custom context variants with `./scripts/model.ps1 create-all` after the Ollama container is online.
-5. Execute `./scripts/context-sweep.ps1 -Safe -CpuOnly -WriteReport` to capture a fresh baseline, then repeat without `-CpuOnly` when GPU resources are ready.
+5. Execute `./scripts/context-sweep.ps1 -Safe -WriteReport` on a CUDA-capable host to close the GPU validation gap, reserving the `-CpuOnly` switch for environments without accelerator access.


### PR DESCRIPTION
## Summary
- add a repository TODO with the current catch-up priorities
- update README guidance to run GPU-enabled context sweeps by default, with CPU fallback notes
- refresh release and status docs so operators capture GPU evidence first

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cac1cb130c832cb689f60dc8aab75f