### PR TITLE
fix: ensure bootstrap seeds context sweep profile

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -68,7 +68,8 @@ function Get-EnvValue {
 
 function Get-EvidenceRoot {
     $configured = Get-EnvValue -Key 'EVIDENCE_ROOT'
-    $null = Ensure-EnvEntry -Path $envLocal -Key 'CONTEXT_SWEEP_PROFILE' -DefaultValue 'llama31-long' -Comment 'Default context sweep profile (llama31-long, qwen3-balanced, cpu-baseline).' -PromptValue:$PromptSecrets
+    $envLocalPath = Join-Path $repoRoot '.env'
+    $null = Ensure-EnvEntry -Path $envLocalPath -Key 'CONTEXT_SWEEP_PROFILE' -DefaultValue 'llama31-long' -Comment 'Default context sweep profile (llama31-long, qwen3-balanced, cpu-baseline).' -PromptValue:$PromptSecrets
     if ($configured) {
         if ([System.IO.Path]::IsPathRooted($configured)) {
             return $configured
@@ -368,6 +369,7 @@ function Invoke-WorkspaceProvisioning {
     $null = Ensure-EnvEntry -Path $envLocal -Key 'OLLAMA_BENCH_MODEL' -DefaultValue 'llama3.1:8b' -Comment 'Default model targeted by scripts/clean/bench_ollama.ps1.' -PromptValue:$PromptSecrets
     $null = Ensure-EnvEntry -Path $envLocal -Key 'OLLAMA_BENCH_PROMPT' -DefaultValue './docs/prompts/bench-default.txt' -Comment 'Prompt file consumed by bench_ollama.ps1 during latency sampling.' -PromptValue:$PromptSecrets
     $null = Ensure-EnvEntry -Path $envLocal -Key 'EVIDENCE_ROOT' -DefaultValue './docs/evidence' -Comment 'Destination directory for diagnostics artifacts.' -PromptValue:$PromptSecrets
+    $null = Ensure-EnvEntry -Path $envLocal -Key 'CONTEXT_SWEEP_PROFILE' -DefaultValue 'llama31-long' -Comment 'Default context sweep profile (llama31-long, qwen3-balanced, cpu-baseline).' -PromptValue:$PromptSecrets
 
     foreach ($directory in @('data', 'models')) {
         Ensure-Directory -Path (Join-Path $repoRoot $directory)

--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -18,7 +18,8 @@ Describe 'scripts/bootstrap.ps1' {
     }
 
     It 'initialises context sweep profile entry' {
-        $bootstrapContent | Should Match 'CONTEXT_SWEEP_PROFILE'
+        $pattern = '(?s)function\s+Invoke-WorkspaceProvisioning.*?Ensure-EnvEntry\s+-Path\s+\$envLocal\s+-Key\s+''CONTEXT_SWEEP_PROFILE'''
+        $bootstrapContent | Should Match $pattern
     }
 }
 


### PR DESCRIPTION
## Summary
- fix Get-EvidenceRoot to seed CONTEXT_SWEEP_PROFILE using the resolved .env path
- provision CONTEXT_SWEEP_PROFILE during workspace bootstrap alongside the other env keys
- tighten the Pester assertion so it specifically checks for the Ensure-EnvEntry call inside Invoke-WorkspaceProvisioning

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb498b8d00832cb050e8ef32bd0e11