### PR TITLE
fix: return env assignment values

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For automation pipelines that must avoid prompts, call `./scripts/bootstrap.ps1 
 - Run a guarded evaluation sweep with GPU validation: `./scripts/context-sweep.ps1 -Safe -WriteReport` (add `-CpuOnly` only when CUDA resources are unavailable to keep evidence flowing into `docs/CONTEXT_RESULTS_*.md`).
 - Tail combined service logs: `./scripts/compose.ps1 logs`.
 - Run automated smoke tests locally with `pip install -r requirements-dev.txt && pytest`. These checks parse `infra/compose/docker-compose.yml`, verify Modelfiles, and validate `.env.example` defaults. The same suite executes in CI via `.github/workflows/smoke-tests.yml`.
+- If PowerShell is unavailable, run `pytest tests/test_powershell_metadata.py` to mirror the lightweight Pester assertions against the helper scripts.
 - GitHub Actions also boots the stack with the CPU override compose file (`infra/compose/docker-compose.ci.yml`), runs Pester + context sweeps, and captures host state for reproducible evidence.
 
 The compose stack is pinned to `ollama/ollama:0.11.11`, `ghcr.io/open-webui/open-webui:v0.3.7`, and `qdrant/qdrant:v1.15.4`. Update the tags in `infra/compose/docker-compose.yml` after validating new releases.

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -59,8 +59,9 @@ function Get-EnvValue {
         return $null
     }
     foreach ($line in Get-Content $envFile) {
-        if ($line -match "^\s*$([regex]::Escape($Key))=(.+)$") {
-            return $Matches[1]
+        $pattern = ("^\s*{0}\s*=\s*(.+)$" -f [regex]::Escape($Key))
+        if ($line -match $pattern) {
+            return $Matches[1].Trim()
         }
     }
     return $null
@@ -68,7 +69,8 @@ function Get-EnvValue {
 
 function Get-EvidenceRoot {
     $configured = Get-EnvValue -Key 'EVIDENCE_ROOT'
-    $null = Ensure-EnvEntry -Path $envLocal -Key 'CONTEXT_SWEEP_PROFILE' -DefaultValue 'llama31-long' -Comment 'Default context sweep profile (llama31-long, qwen3-balanced, cpu-baseline).' -PromptValue:$PromptSecrets
+    $envLocalPath = Join-Path $repoRoot '.env'
+    $null = Ensure-EnvEntry -Path $envLocalPath -Key 'CONTEXT_SWEEP_PROFILE' -DefaultValue 'llama31-long' -Comment 'Default context sweep profile (llama31-long, qwen3-balanced, cpu-baseline).' -PromptValue:$PromptSecrets
     if ($configured) {
         if ([System.IO.Path]::IsPathRooted($configured)) {
             return $configured
@@ -368,6 +370,7 @@ function Invoke-WorkspaceProvisioning {
     $null = Ensure-EnvEntry -Path $envLocal -Key 'OLLAMA_BENCH_MODEL' -DefaultValue 'llama3.1:8b' -Comment 'Default model targeted by scripts/clean/bench_ollama.ps1.' -PromptValue:$PromptSecrets
     $null = Ensure-EnvEntry -Path $envLocal -Key 'OLLAMA_BENCH_PROMPT' -DefaultValue './docs/prompts/bench-default.txt' -Comment 'Prompt file consumed by bench_ollama.ps1 during latency sampling.' -PromptValue:$PromptSecrets
     $null = Ensure-EnvEntry -Path $envLocal -Key 'EVIDENCE_ROOT' -DefaultValue './docs/evidence' -Comment 'Destination directory for diagnostics artifacts.' -PromptValue:$PromptSecrets
+    $null = Ensure-EnvEntry -Path $envLocal -Key 'CONTEXT_SWEEP_PROFILE' -DefaultValue 'llama31-long' -Comment 'Default context sweep profile (llama31-long, qwen3-balanced, cpu-baseline).' -PromptValue:$PromptSecrets
 
     foreach ($directory in @('data', 'models')) {
         Ensure-Directory -Path (Join-Path $repoRoot $directory)

--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -1,41 +1,63 @@
-﻿$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$script:here = if ($PesterScriptRoot) {
+    $PesterScriptRoot
+} elseif ($MyInvocation.MyCommand.Path) {
+    Split-Path -Parent $MyInvocation.MyCommand.Path
+} else {
+    (Get-Location).ProviderPath
+}
+
+$script:repoRoot = [System.IO.Path]::GetFullPath(
+    [System.IO.Path]::Combine($script:here, '..', '..')
+)
 
 Describe 'scripts/compose.ps1' {
-    $composePath = Join-Path $repoRoot 'scripts/compose.ps1'
-    $composeContent = Get-Content -Path $composePath -Raw
+    BeforeAll {
+        $script:composePath = Join-Path $script:repoRoot 'scripts/compose.ps1'
+        $script:composeContent = Get-Content -Path $script:composePath -Raw
+    }
 
     It 'declares expected actions' {
-        $composeContent | Should Match 'ValidateSet\(''up'',''down'',''restart'',''logs''\)'
+        $script:composeContent | Should -Match "ValidateSet\('up','down','restart','logs'\)"
     }
 }
 
 Describe 'scripts/bootstrap.ps1' {
-    $bootstrapPath = Join-Path $repoRoot 'scripts/bootstrap.ps1'
-    $bootstrapContent = Get-Content -Path $bootstrapPath -Raw
+    BeforeAll {
+        $script:bootstrapPath = Join-Path $script:repoRoot 'scripts/bootstrap.ps1'
+        $script:bootstrapContent = Get-Content -Path $script:bootstrapPath -Raw
+    }
 
     It 'supports PromptSecrets switch' {
-        $bootstrapContent | Should Match '\[switch\]\$PromptSecrets'
+        $script:bootstrapContent | Should -Match '\[switch\]\$PromptSecrets'
     }
 
     It 'initialises context sweep profile entry' {
-        $bootstrapContent | Should Match 'CONTEXT_SWEEP_PROFILE'
+        $pattern = '(?s)function\s+Invoke-WorkspaceProvisioning.*?Ensure-EnvEntry\s+-Path\s+\$envLocal\s+-Key\s+''CONTEXT_SWEEP_PROFILE''' 
+        $script:bootstrapContent | Should -Match $pattern
+    }
+
+    It 'Get-EnvValue returns captured assignment value' {
+        $pattern = '(?s)function\s+Get-EnvValue.*?return\s+\$Matches\[1\]\.Trim\(\)'
+        $script:bootstrapContent | Should -Match $pattern
     }
 }
 
 Describe 'context evaluation tooling' {
-    $sweepPath = Join-Path $repoRoot 'scripts/context-sweep.ps1'
-    $sweepContent = Get-Content -Path $sweepPath -Raw
+    BeforeAll {
+        $script:sweepPath = Join-Path $script:repoRoot 'scripts/context-sweep.ps1'
+        $script:sweepContent = Get-Content -Path $script:sweepPath -Raw
+        $script:evalPath = Join-Path $script:repoRoot 'scripts/eval-context.ps1'
+        $script:evalContent = Get-Content -Path $script:evalPath -Raw
+    }
 
     It 'context sweep exposes built-in profiles' {
         foreach ($profile in @('llama31-long','qwen3-balanced','cpu-baseline')) {
             $pattern = [regex]::Escape($profile)
-            $sweepContent | Should Match $pattern
+            $script:sweepContent | Should -Match $pattern
         }
     }
 
     It 'eval-context exposes CpuOnly switch' {
-        $evalPath = Join-Path $repoRoot 'scripts/eval-context.ps1'
-        $evalContent = Get-Content -Path $evalPath -Raw
-        $evalContent | Should Match '\[switch\]\$CpuOnly'
+        $script:evalContent | Should -Match '\[switch\]\$CpuOnly'
     }
 }

--- a/tests/test_powershell_metadata.py
+++ b/tests/test_powershell_metadata.py
@@ -1,0 +1,52 @@
+"""Cross-platform smoke tests for PowerShell helper scripts.
+
+These tests mirror the intent of the Pester suite so contributors without
+PowerShell can still validate the repo state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_compose_script_exposes_expected_actions() -> None:
+    content = read_text("scripts/compose.ps1")
+    assert re.search(r"ValidateSet\('up','down','restart','logs'\)", content)
+
+
+def test_bootstrap_supports_prompt_secrets_switch() -> None:
+    content = read_text("scripts/bootstrap.ps1")
+    assert re.search(r"\[switch\]\$PromptSecrets", content)
+
+
+def test_bootstrap_seeds_context_sweep_profile() -> None:
+    content = read_text("scripts/bootstrap.ps1")
+    pattern = re.compile(
+        r"function\s+Invoke-WorkspaceProvisioning.*?Ensure-EnvEntry\s+-Path\s+\$envLocal\s+-Key\s+'CONTEXT_SWEEP_PROFILE'",
+        re.DOTALL,
+    )
+    assert pattern.search(content)
+
+
+def test_get_env_value_returns_captured_assignment_value() -> None:
+    content = read_text("scripts/bootstrap.ps1")
+    pattern = re.compile(r"function\s+Get-EnvValue.*?return\s+\$Matches\[1\]\.Trim\(\)", re.DOTALL)
+    assert pattern.search(content)
+
+
+def test_context_sweep_lists_builtin_profiles() -> None:
+    content = read_text("scripts/context-sweep.ps1")
+    for profile in ("llama31-long", "qwen3-balanced", "cpu-baseline"):
+        assert profile in content
+
+
+def test_eval_context_exposes_cpu_only_switch() -> None:
+    content = read_text("scripts/eval-context.ps1")
+    assert re.search(r"\[switch\]\$CpuOnly", content)


### PR DESCRIPTION
## Summary
- update Get-EnvValue so it returns the captured assignment value and trims whitespace
- extend the Pester suite to assert the corrected parsing logic in scripts/bootstrap.ps1
- mirror the new parsing assertion in the Python fallback metadata tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb498b8d00832cb050e8ef32bd0e11