### PR TITLE
fix: share repo root constant across Pester suites

### DIFF
--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -1,48 +1,62 @@
-$script:repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+if (-not $PSScriptRoot) {
+    throw 'PSScriptRoot was not populated; unable to determine repository root.'
+}
+
+$testsDirectory = [System.IO.Directory]::GetParent($PSScriptRoot)
+if ($null -eq $testsDirectory) {
+    throw "Unable to locate tests directory from '$PSScriptRoot'."
+}
+
+$repositoryDirectory = [System.IO.Directory]::GetParent($testsDirectory.FullName)
+if ($null -eq $repositoryDirectory) {
+    throw "Unable to resolve repository root from '$($testsDirectory.FullName)'."
+}
+
+$script:RepoRoot = $repositoryDirectory.FullName
 
 Describe 'scripts/compose.ps1' {
     BeforeAll {
-        $script:composePath = Join-Path $script:repoRoot 'scripts/compose.ps1'
-        $script:composeContent = Get-Content -Path $script:composePath -Raw
+        $script:composePath = [System.IO.Path]::Combine($script:RepoRoot, 'scripts', 'compose.ps1')
+        $script:composeContent = [System.IO.File]::ReadAllText($script:composePath)
     }
 
     It 'declares expected actions' {
-        $script:composeContent | Should -Match "ValidateSet\('up','down','restart','logs'\)"
+        ($script:composeContent -match "ValidateSet\('up','down','restart','logs'\)") | Should -BeTrue
     }
 }
 
 Describe 'scripts/bootstrap.ps1' {
     BeforeAll {
-        $script:bootstrapPath = Join-Path $script:repoRoot 'scripts/bootstrap.ps1'
-        $script:bootstrapContent = Get-Content -Path $script:bootstrapPath -Raw
+        $script:bootstrapPath = [System.IO.Path]::Combine($script:RepoRoot, 'scripts', 'bootstrap.ps1')
+        $script:bootstrapContent = [System.IO.File]::ReadAllText($script:bootstrapPath)
     }
 
     It 'supports PromptSecrets switch' {
-        $script:bootstrapContent | Should -Match '\[switch\]\$PromptSecrets'
+        ($script:bootstrapContent -match '\[switch\]\$PromptSecrets') | Should -BeTrue
     }
 
     It 'initialises context sweep profile entry' {
         $pattern = '(?s)function\s+Invoke-WorkspaceProvisioning.*?Ensure-EnvEntry\s+-Path\s+\$envLocal\s+-Key\s+''CONTEXT_SWEEP_PROFILE'''
-        $script:bootstrapContent | Should -Match $pattern
+        ($script:bootstrapContent -match $pattern) | Should -BeTrue
     }
 }
 
 Describe 'context evaluation tooling' {
     BeforeAll {
-        $script:sweepPath = Join-Path $script:repoRoot 'scripts/context-sweep.ps1'
-        $script:sweepContent = Get-Content -Path $script:sweepPath -Raw
-        $script:evalPath = Join-Path $script:repoRoot 'scripts/eval-context.ps1'
-        $script:evalContent = Get-Content -Path $script:evalPath -Raw
+        $script:sweepPath = [System.IO.Path]::Combine($script:RepoRoot, 'scripts', 'context-sweep.ps1')
+        $script:sweepContent = [System.IO.File]::ReadAllText($script:sweepPath)
+        $script:evalPath = [System.IO.Path]::Combine($script:RepoRoot, 'scripts', 'eval-context.ps1')
+        $script:evalContent = [System.IO.File]::ReadAllText($script:evalPath)
     }
 
     It 'context sweep exposes built-in profiles' {
         foreach ($profile in @('llama31-long','qwen3-balanced','cpu-baseline')) {
             $pattern = [regex]::Escape($profile)
-            $script:sweepContent | Should -Match $pattern
+            ($script:sweepContent -match $pattern) | Should -BeTrue
         }
     }
 
     It 'eval-context exposes CpuOnly switch' {
-        $script:evalContent | Should -Match '\[switch\]\$CpuOnly'
+        ($script:evalContent -match '\[switch\]\$CpuOnly') | Should -BeTrue
     }
 }


### PR DESCRIPTION
## Summary
- resolve the repository root during discovery by walking up from `$PSScriptRoot` with .NET directory APIs
- reuse the computed `$script:RepoRoot` when combining script paths so Pester no longer depends on a helper function

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/pester/scripts.Tests.ps1 -Output Detailed"` *(fails: `pwsh` is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb590fc8b8832cb2a4e7b07dde7a0d