### PR TITLE
fix: harden smoke test service probes

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -43,10 +43,10 @@ jobs:
       - name: Probe service health
         run: |
           echo "Waiting for services to initialise"
-          sleep 20
-          curl --fail http://localhost:11434/api/version
-          curl --fail http://localhost:6333/collections
-          curl --fail http://localhost:3000 | head -n 1
+          python scripts/wait_for_http.py --retries 36 --delay 5 --timeout 5 \
+            http://localhost:11434/api/version \
+            http://localhost:6333/collections \
+            http://localhost:3000
 
       - name: Run context sweep (safe CPU profile)
         shell: pwsh

--- a/scripts/wait_for_http.py
+++ b/scripts/wait_for_http.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Utility for polling HTTP endpoints until they report healthy."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Poll one or more HTTP endpoints until they respond successfully. "
+            "A response status in the 200-399 range is treated as healthy."
+        )
+    )
+    parser.add_argument(
+        "urls",
+        metavar="URL",
+        nargs="+",
+        help="HTTP endpoint(s) to poll",
+    )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=24,
+        help="Number of attempts per URL (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=5.0,
+        help="Seconds to wait between attempts (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Per-request timeout in seconds (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def request_ok(url: str, timeout: float) -> bool:
+    request = urllib.request.Request(url)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            return 200 <= response.status < 400
+    except urllib.error.HTTPError as exc:
+        print(f"{url} responded with HTTP {exc.code}")
+        return False
+    except urllib.error.URLError as exc:
+        print(f"{url} not reachable: {exc.reason}")
+        return False
+
+
+def poll_url(url: str, retries: int, delay: float, timeout: float) -> bool:
+    for attempt in range(1, retries + 1):
+        if request_ok(url, timeout):
+            print(f"{url} healthy after {attempt} attempt(s)")
+            return True
+        if attempt == retries:
+            break
+        time.sleep(delay)
+    print(f"{url} failed health check after {retries} attempt(s)")
+    return False
+
+
+def main() -> int:
+    args = parse_args()
+    all_healthy = True
+    for url in args.urls:
+        healthy = poll_url(url=url, retries=args.retries, delay=args.delay, timeout=args.timeout)
+        all_healthy = all_healthy and healthy
+    return 0 if all_healthy else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Python helper that polls HTTP endpoints with configurable retries
- update the smoke-tests workflow to use the new helper instead of fixed sleeps

## Testing
- pytest
- python -m compileall scripts/wait_for_http.py

------
https://chatgpt.com/codex/tasks/task_e_68cb6e05dea8832ca9b815a8846a82cb