### PR TITLE
fix: repair sweep script and stabilize HTTP wait

### DIFF
--- a/scripts/context-sweep.ps1
+++ b/scripts/context-sweep.ps1
@@ -269,4 +269,3 @@ if ($WriteReport) {
     Set-Content -Path $reportPath -Value ($md -join "`n") -Encoding UTF8
     Write-Output ("Wrote report: " + $reportPath)
 }
-}

--- a/scripts/wait_for_http.py
+++ b/scripts/wait_for_http.py
@@ -55,6 +55,9 @@ def request_ok(url: str, timeout: float) -> bool:
     except urllib.error.URLError as exc:
         print(f"{url} not reachable: {exc.reason}")
         return False
+    except ConnectionError as exc:
+        print(f"{url} connection error: {exc}")
+        return False
 
 
 def poll_url(url: str, retries: int, delay: float, timeout: float) -> bool:


### PR DESCRIPTION
## Summary
- remove the stray closing brace left at the end of `scripts/context-sweep.ps1`
- guard `scripts/wait_for_http.py` against raw connection errors so retries can continue

## Testing
- python scripts/wait_for_http.py --retries 1 --delay 0.1 --timeout 0.5 http://127.0.0.1:1
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb74062da4832cbf629ab1d6e3dc1e