### PR TITLE
fix: harden compose automation for linux runners

### DIFF
--- a/docs/FULL_STACK_AUDIT_2025-09-20.md
+++ b/docs/FULL_STACK_AUDIT_2025-09-20.md
@@ -1,0 +1,22 @@
+# Full Stack Audit – 2025-09-20
+
+## Executive Summary
+- GitHub-hosted runners were unable to execute the PowerShell automation that wraps Docker Compose because multiple scripts hard-coded the Windows-style path `infra\compose\docker-compose.yml`. On Linux this string is treated as a literal backslash and the compose file cannot be found, so commands such as `docker compose -f infra\compose\docker-compose.yml config` fail and short-circuit the bootstrap and benchmarking flows that the CI menu relies on.【F:scripts/compose.ps1†L1-L33】【F:scripts/bootstrap.ps1†L323-L356】【F:scripts/clean/bench_ollama.ps1†L1-L52】
+- Central dependency manifests remain aligned: both workflows still install Python tooling from `requirements/python/ci.txt`, which reuses the shared base list documented under `requirements/README.md`, and no drift between local and CI environments was observed.【F:requirements/README.md†L1-L16】【F:.github/workflows/smoke-tests.yml†L20-L47】【F:.github/workflows/syntax-check.yml†L16-L27】
+
+## CI Workflow Health Check
+- `syntax-check.yml` continues to gate bytecode compilation and the fast pytest suite using Python 3.11. No workflow changes were required beyond verifying the dependency pin still resolves against the shared requirement files.【F:.github/workflows/syntax-check.yml†L1-L31】【F:requirements/python/base.txt†L1-L2】
+- `smoke-tests.yml` provisions the stack, performs HTTP probes, and captures a plan-only context sweep so runners do not need to download Ollama weights. The workflow now benefits from the path fixes because any invocation of `scripts/bootstrap.ps1`, `scripts/clean/bench_ollama.ps1`, or similar helpers would otherwise fail when executed on Linux agents.【F:.github/workflows/smoke-tests.yml†L20-L47】【F:scripts/clean/capture_state.ps1†L1-L77】
+
+## Remediation Details
+- Replaced the Windows-specific `Join-Path ... 'infra\compose\docker-compose.yml'` pattern with `[System.IO.Path]::Combine` in every automation entry point (`scripts/compose.ps1`, `scripts/bootstrap.ps1`, `scripts/clean/bench_ollama.ps1`, and `scripts/clean/capture_state.ps1`). This guarantees the compose manifest resolves on both Windows and Linux runners, restoring CI parity.【F:scripts/compose.ps1†L1-L33】【F:scripts/bootstrap.ps1†L331-L349】【F:scripts/clean/bench_ollama.ps1†L1-L52】【F:scripts/clean/capture_state.ps1†L1-L86】
+- Added a regression test to `tests/test_powershell_metadata.py` that fails if `infra\compose` reappears in any of the critical scripts, so future contributors cannot reintroduce Windows-only paths unnoticed.【F:tests/test_powershell_metadata.py†L1-L54】
+- Updated `docs/NEXT_STEPS.md` to reference the portable compose path so operational runbooks no longer suggest the Windows-specific form.【F:docs/NEXT_STEPS.md†L1-L5】
+
+## Validation
+- Python smoke suite: `pytest` covering config, compose, Modelfiles, and PowerShell metadata (includes the new path guard).【7ae7c1†L1-L12】
+- Bytecode compilation: `python -m compileall tests` to mirror the syntax check workflow.【4f21b9†L1-L5】
+
+## Outstanding Follow-Ups
+- Consider adding a lightweight CI smoke step that exercises `scripts/bootstrap.ps1 -Report` on Linux runners now that the path issue is resolved; this would catch future regressions in the bootstrap menu.
+- Monitor the Docker bring-up duration in CI. If containers begin taking longer than the current three-minute polling window, extend the retry count in `scripts/wait_for_http.py` invocations to keep the pipeline stable.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,4 +1,4 @@
-1. Run fresh validation: python -m pytest, Invoke-Pester -Path tests\pester, and docker compose -f infra\compose\docker-compose.yml config.
+1. Run fresh validation: python -m pytest, Invoke-Pester -Path tests\pester, and docker compose -f infra/compose/docker-compose.yml config.
 2. Benchmark via container: ./scripts/clean/bench_ollama.ps1 -Model llama31-8b-gpu -PromptPath docs\prompts\bench-default.txt -Iterations 3.
 3. Capture telemetry: ./scripts/clean/capture_state.ps1 -OutputRoot docs\evidence\ci.
 4. Execute context sweep using desired profile: ./scripts/context-sweep.ps1 -Safe -Profile qwen3-balanced -WriteReport.

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -328,7 +328,7 @@ function Invoke-HostVerification {
 
     $checks += [pscustomobject]@{ Name = 'Docker daemon'; Result = Invoke-CommandSafely -Command 'docker' -Arguments @('info', '--format', '{{.ServerVersion}}'); Description = 'Verifies Docker engine availability.' }
 
-    $composeFile = Join-Path $repoRoot 'infra\compose\docker-compose.yml'
+    $composeFile = [System.IO.Path]::Combine($repoRoot, 'infra', 'compose', 'docker-compose.yml')
     if (Test-Path $composeFile) {
         $checks += [pscustomobject]@{ Name = 'Compose file validation'; Result = Invoke-CommandSafely -Command 'docker' -Arguments @('compose', '-f', $composeFile, 'config'); Description = 'Ensures docker-compose.yml parses.' }
     }

--- a/scripts/clean/bench_ollama.ps1
+++ b/scripts/clean/bench_ollama.ps1
@@ -9,7 +9,7 @@ param(
 $ErrorActionPreference = 'Stop'
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
-$composeFile = Join-Path $repoRoot 'infra\compose\docker-compose.yml'
+$composeFile = [System.IO.Path]::Combine($repoRoot, 'infra', 'compose', 'docker-compose.yml')
 
 function Ensure-Directory {
     param([Parameter(Mandatory = $true)][string]$Path)

--- a/scripts/clean/capture_state.ps1
+++ b/scripts/clean/capture_state.ps1
@@ -134,7 +134,7 @@ if ($IncludeDocker) {
         $report += '- docker info unavailable.'
     }
 
-    $composeFile = Join-Path $repoRoot 'infra\compose\docker-compose.yml'
+    $composeFile = [System.IO.Path]::Combine($repoRoot, 'infra', 'compose', 'docker-compose.yml')
     if (Test-Path $composeFile) {
         $psResult = Invoke-CommandCapture -Command 'docker' -Arguments @('compose', '-f', $composeFile, 'ps')
         if ($psResult.Success -and $psResult.Output) {

--- a/scripts/compose.ps1
+++ b/scripts/compose.ps1
@@ -5,7 +5,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
-$composeFile = Join-Path $repoRoot 'infra\compose\docker-compose.yml'
+$composeFile = [System.IO.Path]::Combine($repoRoot, 'infra', 'compose', 'docker-compose.yml')
 
 if (-not (Test-Path $composeFile)) {
     Write-Error "Compose file not found at: $composeFile`nEnsure you are using the repo at $repoRoot"

--- a/tests/test_powershell_metadata.py
+++ b/tests/test_powershell_metadata.py
@@ -49,3 +49,15 @@ def test_eval_context_exposes_cpu_only_switch() -> None:
 def test_eval_context_avoids_process_exit_on_error() -> None:
     content = read_text("scripts/eval-context.ps1")
     assert "exit 1" not in content.lower(), "eval-context.ps1 should not terminate the calling session on failure"
+
+
+def test_powershell_scripts_use_cross_platform_paths() -> None:
+    scripts = [
+        "scripts/compose.ps1",
+        "scripts/bootstrap.ps1",
+        "scripts/clean/bench_ollama.ps1",
+        "scripts/clean/capture_state.ps1",
+    ]
+    for script in scripts:
+        content = read_text(script)
+        assert "infra\\compose" not in content, f"{script} should avoid Windows-only path separators"


### PR DESCRIPTION
## Summary
- build all PowerShell automation paths with System.IO.Path::Combine so Docker Compose resolves on Linux hosts
- guard against Windows-only separators with a Python regression test and update operational docs accordingly
- record the audit findings in docs/FULL_STACK_AUDIT_2025-09-20.md

## Testing
- python -m pytest
- python -m compileall tests

------
https://chatgpt.com/codex/tasks/task_e_68cbd9ffc2c8832c8c80fe22737c19b1