### PR TITLE
feat: target GPU 1 by default and prune stale evidence

### DIFF
--- a/README-G1MvP.md
+++ b/README-G1MvP.md
@@ -2,6 +2,8 @@
 
 This repository provisions a local, open-source AI stack with Docker Compose. Everything runs on your workstation with no external cloud services required.
 
+> **Note:** `README.md` now carries the canonical runbook and expanded diagnostics guidance. Use this file for a condensed summary when you only need the quickstart checklist.
+
 ## Stack Overview
 - Compose stack pins `ollama/ollama:0.3.14`, `ghcr.io/open-webui/open-webui:v0.3.7`, and `qdrant/qdrant:v1.15.4` for deterministic start-ups.
 - Ollama hosts and serves local LLMs, Open WebUI provides the chat UI, and Qdrant offers vector search for retrieval-augmented workflows.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Optional: Python 3.10+, Node.js LTS, PowerShell 7 for scripts.
 3. Start the stack: `./scripts/compose.ps1 up` (PowerShell).
 4. Open WebUI: http://localhost:3000 (connects to local Ollama at http://localhost:11434).
 
-GPU hosts should layer the GPU overlay when starting the stack directly with Docker Compose: `docker compose -f infra/compose/docker-compose.yml -f infra/compose/docker-compose.gpu.yml up -d`. The base file now defaults Ollama to CPU mode so CI and non-NVIDIA machines can boot the stack without errors; the overlay re-enables CUDA by requesting GPU resources and restoring the NVIDIA environment variables.
+GPU hosts should layer the GPU overlay when starting the stack directly with Docker Compose: `docker compose -f infra/compose/docker-compose.yml -f infra/compose/docker-compose.gpu.yml up -d`. The base file now defaults Ollama to CPU mode so CI and non-NVIDIA machines can boot the stack without errors; the overlay re-enables CUDA by requesting GPU resources and restoring the NVIDIA environment variables while pinning visibility to GPU index 1 (sized for the RTX 3060).
 
 For automation pipelines that must avoid prompts, call `./scripts/bootstrap.ps1 -NoMenu` to skip the interactive menu once provisioning is complete.
 
@@ -35,6 +35,7 @@ The compose stack is pinned to `ollama/ollama:0.3.14`, `ghcr.io/open-webui/open-
 ## Diagnostics & Evidence
 - GPU evaluation and host health snapshots initiated from the bootstrap menu are saved in timestamped folders under `docs/evidence/`.
 - `scripts/clean/capture_state.ps1` mirrors the Clean repository tooling: it captures `nvidia-smi` summaries, Ollama inventory, and optional Docker metadata to `docs/evidence/state/<timestamp>/`.
+- `scripts/clean/prune_evidence.ps1` prunes old snapshots from `docs/evidence/state/`, keeping the newest runs (default 5) or directories younger than the `-MaxAgeDays` threshold so evidence rotation can run unattended.
 - `scripts/clean/bench_ollama.ps1` runs repeatable latency and throughput measurements against the model defined in `.env` (default `llama3.1:8b`) using the prompt stored at `docs/prompts/bench-default.txt`. Results land in `docs/evidence/benchmarks/` as Markdown + JSON artifacts.
 - To change evidence destinations, adjust `EVIDENCE_ROOT` inside `.env`; all diagnostics respect this path.
 
@@ -67,8 +68,8 @@ See `docs/ARCHITECTURE.md` for details.
 - `docs/FULL_STACK_AUDIT_2025-09-19.md`: Latest CI and dependency audit capturing the plan-only sweep change and tooling convergence.
 - `docs/TASK_TEST_HARDENING_PROMPT_2025-09-18.md`: Actionable brief to close testing gaps before declaring release readiness.
 ### GPU targeting
-- The GPU-tuned Modelfile now defaults to `main_gpu 0` so single-GPU hosts can create it without edits.
-- Override the GPU index when needed: `./scripts/model.ps1 create -Model llama31-8b-gpu -MainGpu 1` or `./scripts/model.ps1 create-all -MainGpu 1`.
+- The GPU-tuned Modelfile now defaults to `main_gpu 1` so RTX 3060 hosts target the second adapter without manual edits.
+- Override the GPU index when needed: `./scripts/model.ps1 create -Model llama31-8b-gpu -MainGpu 0` or `./scripts/model.ps1 create-all -MainGpu 2` to target other adapters.
 - Context variants ignore the override, but the helper script applies it when the GPU profile is built.
 
 ### Context sweeps

--- a/infra/compose/docker-compose.gpu.yml
+++ b/infra/compose/docker-compose.gpu.yml
@@ -1,7 +1,7 @@
 services:
   ollama:
     environment:
-      - NVIDIA_VISIBLE_DEVICES=${OLLAMA_VISIBLE_GPUS:-all}
+      - NVIDIA_VISIBLE_DEVICES=${OLLAMA_VISIBLE_GPUS:-1}
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
       - OLLAMA_USE_CPU=${OLLAMA_USE_CPU:-false}
-    gpus: ${OLLAMA_GPU_ALLOCATION:-all}
+    gpus: ${OLLAMA_GPU_ALLOCATION:-device=1}

--- a/modelfiles/llama31-8b-gpu.Modelfile
+++ b/modelfiles/llama31-8b-gpu.Modelfile
@@ -3,8 +3,8 @@ FROM llama3.1:8b
 # Offload as many layers as possible to GPU
 PARAMETER num_gpu 999
 
-# Default to GPU index 0; override via scripts/model.ps1 -MainGpu
-PARAMETER main_gpu 0
+# Default to GPU index 1; override via scripts/model.ps1 -MainGpu
+PARAMETER main_gpu 1
 
 # Optional: context window
 PARAMETER num_ctx 4096

--- a/scripts/clean/prune_evidence.ps1
+++ b/scripts/clean/prune_evidence.ps1
@@ -62,18 +62,18 @@ $removals = @()
 
 for ($index = 0; $index -lt $directories.Count; $index++) {
     $dir = $directories[$index]
-    $remove = $false
     $withinRetention = $index -lt $Keep
 
-    if ($index -ge $Keep) {
-        $remove = $true
+    if ($withinRetention) {
+        continue
     }
 
-    if (-not $withinRetention -and $threshold -and $dir.LastWriteTime -lt $threshold) {
-        $remove = $true
+    if (-not $threshold) {
+        $removals += $dir
+        continue
     }
 
-    if ($remove) {
+    if ($dir.LastWriteTime -lt $threshold) {
         $removals += $dir
     }
 }

--- a/scripts/clean/prune_evidence.ps1
+++ b/scripts/clean/prune_evidence.ps1
@@ -63,12 +63,13 @@ $removals = @()
 for ($index = 0; $index -lt $directories.Count; $index++) {
     $dir = $directories[$index]
     $remove = $false
+    $withinRetention = $index -lt $Keep
 
     if ($index -ge $Keep) {
         $remove = $true
     }
 
-    if ($threshold -and $dir.LastWriteTime -lt $threshold) {
+    if (-not $withinRetention -and $threshold -and $dir.LastWriteTime -lt $threshold) {
         $remove = $true
     }
 

--- a/scripts/clean/prune_evidence.ps1
+++ b/scripts/clean/prune_evidence.ps1
@@ -1,0 +1,90 @@
+param(
+    [ValidateRange(0, [int]::MaxValue)]
+    [int]$Keep = 5,
+    [ValidateRange(0, [int]::MaxValue)]
+    [int]$MaxAgeDays = 0,
+    [string]$Root
+)
+
+$ErrorActionPreference = 'Stop'
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptRoot
+
+function Get-EnvValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Key
+    )
+
+    $envFile = Join-Path -Path $repoRoot -ChildPath '.env'
+    if (-not (Test-Path -Path $envFile)) {
+        return $null
+    }
+
+    foreach ($line in Get-Content -Path $envFile) {
+        if ($line -match "^\s*$([regex]::Escape($Key))=(.+)$") {
+            return $Matches[1]
+        }
+    }
+
+    return $null
+}
+
+if (-not $Root) {
+    $envRoot = Get-EnvValue -Key 'EVIDENCE_ROOT'
+    if ($envRoot) {
+        $Root = if ([System.IO.Path]::IsPathRooted($envRoot)) {
+            $envRoot
+        }
+        else {
+            Join-Path -Path $repoRoot -ChildPath $envRoot
+        }
+    }
+    else {
+        $Root = Join-Path -Path $repoRoot -ChildPath 'docs/evidence'
+    }
+}
+
+$stateRoot = Join-Path -Path $Root -ChildPath 'state'
+if (-not (Test-Path -Path $stateRoot)) {
+    Write-Host "State evidence directory not found at $stateRoot. Nothing to prune."
+    return
+}
+
+$directories = Get-ChildItem -Path $stateRoot -Directory | Sort-Object -Property LastWriteTime -Descending
+if (-not $directories) {
+    Write-Host "No state evidence directories discovered under $stateRoot."
+    return
+}
+
+$threshold = if ($MaxAgeDays -gt 0) { (Get-Date).AddDays(-$MaxAgeDays) } else { $null }
+$removals = @()
+
+for ($index = 0; $index -lt $directories.Count; $index++) {
+    $dir = $directories[$index]
+    $remove = $false
+
+    if ($index -ge $Keep) {
+        $remove = $true
+    }
+
+    if ($threshold -and $dir.LastWriteTime -lt $threshold) {
+        $remove = $true
+    }
+
+    if ($remove) {
+        $removals += $dir
+    }
+}
+
+if ($removals.Count -eq 0) {
+    Write-Host "No evidence directories required pruning."
+    return
+}
+
+foreach ($directory in $removals) {
+    Write-Host "Removing $($directory.FullName)"
+    Remove-Item -Path $directory.FullName -Recurse -Force -ErrorAction Stop
+}
+
+Write-Host ("Pruned {0} state evidence director{1}." -f $removals.Count, $(if ($removals.Count -eq 1) { 'y' } else { 'ies' }))

--- a/tests/infra/test_docker_compose.py
+++ b/tests/infra/test_docker_compose.py
@@ -121,12 +121,12 @@ def test_gpu_overlay_requests_cuda_resources() -> None:
     ollama = GPU_SERVICES_CACHE["ollama"]
 
     assert (
-        ollama.get("gpus") == "${OLLAMA_GPU_ALLOCATION:-all}"
-    ), "GPU overlay must request GPU resources"
+        ollama.get("gpus") == "${OLLAMA_GPU_ALLOCATION:-device=1}"
+    ), "GPU overlay must request GPU resources on GPU 1 by default"
 
     environment: List[str] = ollama.get("environment", [])  # type: ignore[assignment]
     expected_pairs = {
-        "NVIDIA_VISIBLE_DEVICES=${OLLAMA_VISIBLE_GPUS:-all}",
+        "NVIDIA_VISIBLE_DEVICES=${OLLAMA_VISIBLE_GPUS:-1}",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
         "OLLAMA_USE_CPU=${OLLAMA_USE_CPU:-false}",
     }

--- a/tests/modelfiles/test_modelfiles.py
+++ b/tests/modelfiles/test_modelfiles.py
@@ -36,7 +36,10 @@ def test_gpu_modelfile_declares_gpu_parameters() -> None:
 
     lines = normalise_lines(gpu_file)
     assert any(line.startswith("PARAMETER num_gpu") for line in lines), "GPU Modelfile must request GPU layers"
-    assert any(line.startswith("PARAMETER main_gpu") for line in lines), "GPU Modelfile must nominate a primary GPU"
+    main_gpu_lines = [line for line in lines if line.startswith("PARAMETER main_gpu")]
+    assert main_gpu_lines == [
+        "PARAMETER main_gpu 1"
+    ], "GPU Modelfile must nominate GPU index 1 by default"
 
 
 def test_context_window_parameters_are_positive() -> None:

--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -50,3 +50,18 @@ Describe 'context evaluation tooling' {
         ($script:evalContent -match '\[switch\]\$CpuOnly') | Should -BeTrue
     }
 }
+
+Describe 'scripts/clean/prune_evidence.ps1' {
+    BeforeAll {
+        $script:prunePath = Join-Path -Path $repoRoot -ChildPath 'scripts/clean/prune_evidence.ps1'
+        $script:pruneContent = Get-Content -Path $script:prunePath -Raw
+    }
+
+    It 'defines Keep parameter with default of 5' {
+        ($script:pruneContent -match "\[int\]\$Keep = 5") | Should -BeTrue
+    }
+
+    It 'reads EVIDENCE_ROOT from .env when Root not provided' {
+        ($script:pruneContent -match "Get-EnvValue -Key 'EVIDENCE_ROOT'") | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- default the GPU compose overlay and GPU Modelfile to target index 1 for RTX 3060 hosts
- add a PowerShell helper to prune stale evidence snapshots and document the workflow updates
- extend pytest and Pester smoke coverage to assert the new defaults and tooling

## Testing
- `pip install -r requirements/python/dev.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cbe2361d74832c8a5adc744ef67bdd