### PR TITLE
fix: ensure Pester tests determine script root

### DIFF
--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -1,12 +1,14 @@
-if (-not $PSScriptRoot) {
-    $PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$scriptRoot = $PSScriptRoot
+
+if (-not $scriptRoot) {
+    $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
 }
 
-if (-not $PSScriptRoot) {
+if (-not $scriptRoot) {
     throw "PSScriptRoot was not populated; unable to determine repository root."
 }
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
 
 Describe 'scripts/compose.ps1' {
     BeforeAll {


### PR DESCRIPTION
## Summary
- add a fallback to populate `$PSScriptRoot` via `$MyInvocation.MyCommand.Definition`
- keep the existing guard that raises an error when the script root cannot be determined
- ensure repository-relative paths used in Pester tests are always resolved

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Script tests/pester/scripts.Tests.ps1"` *(fails: command not found)*
- `pwsh -NoLogo -Command "Invoke-ScriptAnalyzer -Path tests/pester/scripts.Tests.ps1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbeb3fd764832c942cc41d9bd71993