### PR TITLE
Streamline compose stack and tighten env handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,10 @@
 # Ports
 WEBUI_PORT=3000
 OLLAMA_PORT=11434
-OLLAMA_GPU0_PORT=11435
-OLLAMA_GPU1_PORT=11436
 QDRANT_PORT=6333
 
-# Paths (relative to repo root)
+# Paths (relative to the repository root)
+# The compose helper resolves these into absolute paths before invoking Docker.
 MODELS_DIR=./models
 DATA_DIR=./data
 

--- a/docs/STATE_VERIFICATION.md
+++ b/docs/STATE_VERIFICATION.md
@@ -1,0 +1,31 @@
+# State Verification Checklist
+
+This document tracks the current stability of the stack and the checks that keep it reproducible.
+
+## Stable Today
+- **Infrastructure compose files** – `infra/compose/docker-compose.yml` (CPU baseline) and `infra/compose/docker-compose.ci.yml` (CI overrides) run with the repository `.env` and resolve storage paths automatically.
+- **Helper tooling** – `scripts/compose.ps1` now forwards `--env-file` and accepts optional overlays via `-File`, enforcing non-zero exit codes from Docker.
+- **Core services** – Ollama, Open WebUI, and Qdrant start cleanly on Docker Desktop / Engine without GPU access.
+- **Python guardrails** – `pytest` validates compose manifests, `.env.example`, and Modelfiles without network access.
+
+## Experimental or Host-Dependent
+- **GPU overlay** – `infra/compose/docker-compose.gpu.yml` is optional and depends on NVIDIA container support. Treat failures as host-specific until validated on real hardware.
+- **Context sweeps** – `./scripts/context-sweep.ps1` supports plan-only runs in CI. Full sweeps still require local model downloads and sufficient VRAM.
+- **PowerShell-only tooling** – the richer diagnostics (capture-state, benchmarking) need PowerShell 7 and may not run on minimal shells.
+
+## Verification Steps
+Run these checks after changing infrastructure, scripts, or documentation referenced by the stack:
+
+```powershell
+# Python smoke tests
+python -m pip install -r requirements/python/dev.txt
+pytest
+
+# Optional PowerShell mirror
+pwsh -File tests/pester/scripts.Tests.ps1
+
+# Optional context sweep (plan only keeps CI lightweight)
+./scripts/context-sweep.ps1 -Safe -CpuOnly -PlanOnly -WriteReport
+```
+
+Record the outcomes in `docs/evidence/` when promoting a change to ensure reviewers can audit the run.

--- a/infra/compose/docker-compose.gpu.yml
+++ b/infra/compose/docker-compose.gpu.yml
@@ -6,19 +6,3 @@ services:
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
       - OLLAMA_USE_CPU=${OLLAMA_USE_CPU:-false}
     gpus: ${OLLAMA_GPU_ALLOCATION:-all}
-
-  ollama-gpu0:
-    environment:
-      - OLLAMA_HOST=0.0.0.0
-      - NVIDIA_VISIBLE_DEVICES=${OLLAMA_GPU0_VISIBLE_GPUS:-0}
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
-      - OLLAMA_USE_CPU=${OLLAMA_GPU0_USE_CPU:-false}
-    gpus: ${OLLAMA_GPU0_GPU_ALLOCATION:-device=0}
-
-  ollama-gpu1:
-    environment:
-      - OLLAMA_HOST=0.0.0.0
-      - NVIDIA_VISIBLE_DEVICES=${OLLAMA_GPU1_VISIBLE_GPUS:-1}
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
-      - OLLAMA_USE_CPU=${OLLAMA_GPU1_USE_CPU:-false}
-    gpus: ${OLLAMA_GPU1_GPU_ALLOCATION:-device=1}

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -9,31 +9,7 @@ services:
       - OLLAMA_USE_CPU=${OLLAMA_USE_CPU:-true}
     volumes:
       - ../../modelfiles:/modelfiles
-      - ${DATA_DIR:-../../data}/models:/root/.ollama
-
-  ollama-gpu0:
-    image: ollama/ollama:0.3.11
-    restart: unless-stopped
-    ports:
-      - "${OLLAMA_GPU0_PORT:-11435}:11434"
-    environment:
-      - OLLAMA_HOST=0.0.0.0
-      - OLLAMA_USE_CPU=${OLLAMA_GPU0_USE_CPU:-true}
-    volumes:
-      - ../../modelfiles:/modelfiles
-      - ${DATA_DIR:-../../data}/models-gpu0:/root/.ollama
-
-  ollama-gpu1:
-    image: ollama/ollama:0.3.11
-    restart: unless-stopped
-    ports:
-      - "${OLLAMA_GPU1_PORT:-11436}:11434"
-    environment:
-      - OLLAMA_HOST=0.0.0.0
-      - OLLAMA_USE_CPU=${OLLAMA_GPU1_USE_CPU:-true}
-    volumes:
-      - ../../modelfiles:/modelfiles
-      - ${DATA_DIR:-../../data}/models-gpu1:/root/.ollama
+      - ../../${MODELS_DIR:-models}:/root/.ollama
 
   open-webui:
     image: ghcr.io/open-webui/open-webui:v0.6.30
@@ -46,7 +22,7 @@ services:
       - OLLAMA_BASE_URL=http://ollama:11434
       - WEBUI_AUTH=${OPENWEBUI_AUTH:-false}
     volumes:
-      - ${DATA_DIR:-../../data}/open-webui:/app/backend/data
+      - ../../${DATA_DIR:-data}/open-webui:/app/backend/data
 
   qdrant:
     image: qdrant/qdrant:v1.15.4
@@ -54,7 +30,7 @@ services:
     ports:
       - "${QDRANT_PORT:-6333}:6333"
     volumes:
-      - ${DATA_DIR:-../../data}/qdrant:/qdrant/storage
+      - ../../${DATA_DIR:-data}/qdrant:/qdrant/storage
 
 volumes: {}
 

--- a/scripts/compose.ps1
+++ b/scripts/compose.ps1
@@ -1,22 +1,63 @@
 param(
     [ValidateSet('up','down','restart','logs')]
-    [string]$Action = 'up'
+    [string]$Action = 'up',
+    [string[]]$File = @()
 )
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
-$composeFile = [System.IO.Path]::Combine($repoRoot, 'infra', 'compose', 'docker-compose.yml')
+$composeRoot = Join-Path -Path $repoRoot -ChildPath 'infra/compose'
+$composeFile = Join-Path -Path $composeRoot -ChildPath 'docker-compose.yml'
+
+function Resolve-ComposePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+
+    return Join-Path -Path $composeRoot -ChildPath $Path
+}
 
 if (-not (Test-Path $composeFile)) {
     Write-Error "Compose file not found at: $composeFile`nEnsure you are using the repo at $repoRoot"
     exit 1
 }
 
+$composeFile = (Get-Item -LiteralPath $composeFile).FullName
+
+$envFile = Join-Path -Path $repoRoot -ChildPath '.env'
+if (-not (Test-Path -LiteralPath $envFile)) {
+    $envTemplate = Join-Path -Path $repoRoot -ChildPath '.env.example'
+    if (Test-Path -LiteralPath $envTemplate) {
+        Write-Warning "No .env found at $envFile. Falling back to template overrides."
+        $envFile = $envTemplate
+    }
+    else {
+        Write-Error "No environment file found. Create .env or copy from .env.example first."
+        exit 1
+    }
+}
+
+$envFile = (Get-Item -LiteralPath $envFile).FullName
+
 $exitCode = 0
 
 Push-Location $repoRoot
 try {
-    $composeArgs = @('compose', '-f', $composeFile)
+    $composeArgs = @('compose', '--env-file', $envFile, '-f', $composeFile)
+
+    foreach ($overlay in $File) {
+        $resolved = Resolve-ComposePath -Path $overlay
+        if (-not (Test-Path -LiteralPath $resolved)) {
+            Write-Error "Compose overlay not found: $overlay"
+            exit 1
+        }
+        $composeArgs += @('-f', (Get-Item -LiteralPath $resolved).FullName)
+    }
+
     switch ($Action) {
         'up' { $composeArgs += @('up', '-d') }
         'down' { $composeArgs += @('down') }

--- a/tests/config/test_env_example.py
+++ b/tests/config/test_env_example.py
@@ -31,8 +31,6 @@ def test_env_example_contains_expected_keys() -> None:
     expected_keys = {
         "WEBUI_PORT",
         "OLLAMA_PORT",
-        "OLLAMA_GPU0_PORT",
-        "OLLAMA_GPU1_PORT",
         "QDRANT_PORT",
         "MODELS_DIR",
         "DATA_DIR",
@@ -50,7 +48,7 @@ def test_env_example_contains_expected_keys() -> None:
 
 def test_ports_are_numeric() -> None:
     env = load_env()
-    for key in ("WEBUI_PORT", "OLLAMA_PORT", "OLLAMA_GPU0_PORT", "OLLAMA_GPU1_PORT", "QDRANT_PORT"):
+    for key in ("WEBUI_PORT", "OLLAMA_PORT", "QDRANT_PORT"):
         value = env[key]
         assert value.isdigit(), f"{key} should be a numeric port"
 

--- a/tests/infra/test_docker_compose.py
+++ b/tests/infra/test_docker_compose.py
@@ -76,30 +76,9 @@ GPU_SERVICES_CACHE = parse_services(GPU_COMPOSE_PATH)
 
 
 def test_compose_declares_expected_services() -> None:
-    expected_services = {"ollama", "ollama-gpu0", "ollama-gpu1", "open-webui", "qdrant"}
+    expected_services = {"ollama", "open-webui", "qdrant"}
     missing = expected_services.difference(SERVICES_CACHE)
     assert not missing, f"missing required services: {sorted(missing)}"
-
-
-def test_isolated_gpu_services_default_to_cpu() -> None:
-    for name, port_key, cpu_key in (
-        ("ollama-gpu0", "OLLAMA_GPU0_PORT", "OLLAMA_GPU0_USE_CPU"),
-        ("ollama-gpu1", "OLLAMA_GPU1_PORT", "OLLAMA_GPU1_USE_CPU"),
-    ):
-        service = SERVICES_CACHE[name]
-
-        environment: List[str] = service.get("environment", [])  # type: ignore[assignment]
-        assert "OLLAMA_HOST=0.0.0.0" in environment, f"{name} must bind to 0.0.0.0"
-        expected_cpu = "OLLAMA_USE_CPU=${" + cpu_key + ":-true}"
-        assert expected_cpu in environment, f"{name} must default to CPU mode"
-
-        ports: List[str] = service.get("ports", [])  # type: ignore[assignment]
-        default_port = "11435" if name.endswith("0") else "11436"
-        expected_port = "${" + port_key + ":-" + default_port + "}:11434"
-        assert any(entry.strip('"') == expected_port for entry in ports), f"{name} must expose a host port"
-
-        volumes: List[str] = service.get("volumes", [])  # type: ignore[assignment]
-        assert any("../../modelfiles" in volume for volume in volumes), f"{name} must mount modelfiles"
 
 
 def test_images_are_pinned_and_not_latest() -> None:
@@ -135,6 +114,19 @@ def test_ollama_defaults_to_cpu_mode() -> None:
 
     volumes: List[str] = ollama.get("volumes", [])  # type: ignore[assignment]
     assert any("../../modelfiles" in volume for volume in volumes), "ollama volume mounts must include modelfiles"
+    assert any(
+        volume.strip('"') == "../../${MODELS_DIR:-models}:/root/.ollama" for volume in volumes
+    ), "ollama should persist models using MODELS_DIR override"
+
+
+def test_data_root_expands_via_env_defaults() -> None:
+    for name in ("open-webui", "qdrant"):
+        service = SERVICES_CACHE[name]
+        volumes: List[str] = service.get("volumes", [])  # type: ignore[assignment]
+        assert volumes, f"{name} must declare volumes"
+        assert any(
+            volume.strip('"').startswith("../../${DATA_DIR:-data}/") for volume in volumes
+        ), f"{name} volumes should be driven by DATA_DIR overrides"
 
 
 def test_gpu_overlay_requests_cuda_resources() -> None:
@@ -154,26 +146,6 @@ def test_gpu_overlay_requests_cuda_resources() -> None:
         assert pair in environment, f"GPU overlay environment missing {pair}"
 
 
-
-
-def test_gpu_overlay_pins_isolated_devices() -> None:
-    for name, visible_key, cpu_key, allocation_key, default_device in (
-        ("ollama-gpu0", "OLLAMA_GPU0_VISIBLE_GPUS", "OLLAMA_GPU0_USE_CPU", "OLLAMA_GPU0_GPU_ALLOCATION", "0"),
-        ("ollama-gpu1", "OLLAMA_GPU1_VISIBLE_GPUS", "OLLAMA_GPU1_USE_CPU", "OLLAMA_GPU1_GPU_ALLOCATION", "1"),
-    ):
-        service = GPU_SERVICES_CACHE[name]
-
-        environment: List[str] = service.get("environment", [])  # type: ignore[assignment]
-        expected_pairs = {
-            "NVIDIA_VISIBLE_DEVICES=${" + visible_key + ":-" + default_device + "}",
-            "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
-            "OLLAMA_USE_CPU=${" + cpu_key + ":-false}",
-        }
-        for pair in expected_pairs:
-            assert pair in environment, f"{name} GPU overlay environment missing {pair}"
-
-        expected_gpus = "${" + allocation_key + ":-device=" + default_device + "}"
-        assert service.get("gpus") == expected_gpus, f"{name} GPU allocation should request a single device"
 
 
 def test_open_webui_uses_expected_env_defaults() -> None:

--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -40,6 +40,11 @@ Describe 'scripts/compose.ps1' {
     It 'declares expected actions' {
         ($script:composeContent -match "ValidateSet\('up','down','restart','logs'\)") | Should -BeTrue
     }
+
+    It 'bubbles repository env file and overlays to docker compose' {
+        ($script:composeContent -match '--env-file') | Should -BeTrue
+        ($script:composeContent -match '\[string\[\]\]\$File') | Should -BeTrue
+    }
 }
 
 Describe 'scripts/bootstrap.ps1' {

--- a/tests/test_powershell_metadata.py
+++ b/tests/test_powershell_metadata.py
@@ -19,6 +19,8 @@ def read_text(relative_path: str) -> str:
 def test_compose_script_exposes_expected_actions() -> None:
     content = read_text("scripts/compose.ps1")
     assert re.search(r"ValidateSet\('up','down','restart','logs'\)", content)
+    assert "--env-file" in content, "compose helper should pass repository env file to docker"
+    assert "[string[]]$File" in content, "compose helper should expose overlay parameter"
 
 
 def test_bootstrap_supports_prompt_secrets_switch() -> None:


### PR DESCRIPTION
## Summary
- simplify the compose stack to a single Ollama service and drive volume paths from MODELS_DIR/DATA_DIR defaults
- teach scripts/compose.ps1 to pass the repository .env, accept overlays, and document the lean workflow with a new state checklist
- align the Python and Pester smoke tests plus .env.example with the minimal stack layout

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc58b2c680832cb5d3df38f6a20f2a