### PR TITLE
fix: normalise bootstrap provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository ships a minimal Docker Compose stack for running a single Ollama
 - Optional: Node.js LTS if you work with the Codex CLI utilities
 
 ## Quickstart
-1. **Bootstrap the workspace** – `./scripts/bootstrap.ps1 -PromptSecrets` seeds `.env`, ensures the `models/` folder exists, and runs the basic host checks.
+1. **Bootstrap the workspace** – `./scripts/bootstrap.ps1 -PromptSecrets` seeds `.env`, provisions the directories referenced by `MODELS_DIR`, `EVIDENCE_ROOT`, and `LOG_FILE`, and runs the basic host checks.
 2. **Review `.env`** – adjust `OLLAMA_IMAGE`, `OLLAMA_PORT`, or `MODELS_DIR` as required. The compose helper resolves relative paths against the repository root automatically.
 3. **Start the stack** – `./scripts/compose.ps1 up` brings up the Ollama service using the repository `.env`. Add overlays with `-File` when experimenting:
    ```powershell

--- a/docs/STATE_VERIFICATION.md
+++ b/docs/STATE_VERIFICATION.md
@@ -1,10 +1,22 @@
 # State Verification Checklist
 
-This checklist highlights the current stability of the minimal stack and the checks that keep it reproducible.
+This checklist highlights the current stability of the minimal stack and the guardrails that keep it reproducible. Images and dependencies remain intentionally unpinned so overlays can evolve without fragmenting the base workflow.
+
+## Status Snapshot
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Compose manifest | ✅ Stable | `infra/compose/docker-compose.yml` starts a single Ollama service and honours `OLLAMA_IMAGE`, `OLLAMA_PORT`, and `MODELS_DIR` overrides from `.env`. |
+| Bootstrap & directories | ✅ Stable | `scripts/bootstrap.ps1` seeds `.env`, provisions the `MODELS_DIR`, evidence root, and the parent of `LOG_FILE`, and confirms helper dependencies. |
+| Baseline Modelfile | ✅ Stable | `modelfiles/baseline.Modelfile` wraps `llama3.1` with conservative CPU defaults while forwarding the prompt template unchanged. |
+| Python guardrails | ✅ Stable | `pytest` validates the compose manifest, `.env.example`, and Modelfiles without contacting external services. |
+| GPU overlay | ⚠️ Host-dependent | `infra/compose/docker-compose.gpu.yml` expects NVIDIA container support and should be treated as experimental until validated on real hardware. |
+| Context sweeps | ⚠️ Host-dependent | `./scripts/context-sweep.ps1` offers plan-only runs in CI; full executions still require local model downloads and sufficient CPU/GPU capacity. |
+| Additional overlays | ⚠️ Host-dependent | Any service layered on top of the minimal stack must ship its own verification steps to remain modular. |
 
 ## Stable Today
-- **Compose manifest** – `infra/compose/docker-compose.yml` starts a single Ollama container and honours `OLLAMA_IMAGE`, `OLLAMA_PORT`, and `MODELS_DIR` overrides from `.env`.
-- **Helper scripts** – `scripts/bootstrap.ps1`, `scripts/compose.ps1`, and `scripts/model.ps1 create-all` operate cross-platform and surface non-zero exit codes when Docker or PowerShell fail.
+- **Compose manifest** – `infra/compose/docker-compose.yml` starts a single Ollama container and honours runtime overrides from `.env`.
+- **Helper scripts** – `scripts/bootstrap.ps1`, `scripts/compose.ps1`, and `scripts/model.ps1 create-all` operate cross-platform, create the directories referenced by `MODELS_DIR`, `EVIDENCE_ROOT`, and `LOG_FILE`, and surface non-zero exit codes when Docker or PowerShell fail.
 - **Baseline Modelfile** – `modelfiles/baseline.Modelfile` wraps `llama3.1` with conservative CPU defaults and passes the template through unchanged.
 - **Python guardrails** – `pytest` validates the compose manifest, `.env.example`, and Modelfiles without contacting external services.
 

--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -68,6 +68,13 @@ Describe 'scripts/bootstrap.ps1' {
             ($script:bootstrapContent -match $pattern) | Should -BeTrue
         }
     }
+
+    It 'normalises repository-relative directories' {
+        $script:bootstrapContent.Contains('function Resolve-RepoPath') | Should -BeTrue
+        $script:bootstrapContent.Contains('Resolve-RepoPath -Path $modelsDirValue') | Should -BeTrue
+        $script:bootstrapContent.Contains('Resolve-RepoPath -Path $logDirValue') | Should -BeTrue
+        $script:bootstrapContent.Contains('[System.IO.Path]::GetDirectoryName($logFileValue)') | Should -BeTrue
+    }
 }
 
 Describe 'context evaluation tooling' {

--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -2,27 +2,27 @@ if (-not $PSScriptRoot) {
     throw "PSScriptRoot was not populated; unable to determine repository root."
 }
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$script:repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 
-if (-not $repoRoot) {
+if (-not $script:repoRoot) {
     throw "Unable to resolve repository root from PSScriptRoot: $PSScriptRoot"
 }
 
-if (-not (Test-Path -Path $repoRoot -PathType Container)) {
-    throw "Resolved repository root does not exist: $repoRoot"
+if (-not (Test-Path -Path $script:repoRoot -PathType Container)) {
+    throw "Resolved repository root does not exist: $script:repoRoot"
 }
 
-function Get-RequiredFileContent {
+function script:Get-RequiredFileContent {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string] $RelativePath
     )
 
-    $fullPath = Join-Path -Path $repoRoot -ChildPath $RelativePath
+    $fullPath = Join-Path -Path $script:repoRoot -ChildPath $RelativePath
 
     if (-not $fullPath) {
-        throw "Failed to build a path for '$RelativePath' from repository root '$repoRoot'."
+        throw "Failed to build a path for '$RelativePath' from repository root '$($script:repoRoot)'."
     }
 
     if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
@@ -79,10 +79,8 @@ Describe 'scripts/bootstrap.ps1' {
 
 Describe 'context evaluation tooling' {
     BeforeAll {
-        $script:sweepPath = Join-Path -Path $repoRoot -ChildPath 'scripts/context-sweep.ps1'
-        $script:sweepContent = Get-Content -Path $script:sweepPath -Raw
-        $script:evalPath = Join-Path -Path $repoRoot -ChildPath 'scripts/eval-context.ps1'
-        $script:evalContent = Get-Content -Path $script:evalPath -Raw
+        $script:sweepContent = Get-RequiredFileContent -RelativePath 'scripts/context-sweep.ps1'
+        $script:evalContent = Get-RequiredFileContent -RelativePath 'scripts/eval-context.ps1'
     }
 
     It 'context sweep exposes built-in profiles' {
@@ -100,8 +98,7 @@ Describe 'context evaluation tooling' {
 
 Describe 'scripts/clean/prune_evidence.ps1' {
     BeforeAll {
-        $script:prunePath = Join-Path -Path $repoRoot -ChildPath 'scripts/clean/prune_evidence.ps1'
-        $script:pruneContent = Get-Content -Path $script:prunePath -Raw
+        $script:pruneContent = Get-RequiredFileContent -RelativePath 'scripts/clean/prune_evidence.ps1'
     }
 
     It 'defines Keep parameter with default of 5' {

--- a/tests/test_powershell_metadata.py
+++ b/tests/test_powershell_metadata.py
@@ -44,6 +44,14 @@ def test_bootstrap_seeds_runtime_overrides() -> None:
         assert expected in content, f"bootstrap should ensure {key} entry"
 
 
+def test_bootstrap_normalises_repo_relative_directories() -> None:
+    content = read_text("scripts/bootstrap.ps1")
+    assert "function Resolve-RepoPath" in content
+    assert "Resolve-RepoPath -Path $modelsDirValue" in content
+    assert "Resolve-RepoPath -Path $logDirValue" in content
+    assert "[System.IO.Path]::GetDirectoryName($logFileValue)" in content
+
+
 def test_context_sweep_lists_builtin_profiles() -> None:
     content = read_text("scripts/context-sweep.ps1")
     for profile in ("baseline-cpu",):


### PR DESCRIPTION
## Summary
- add a Resolve-RepoPath helper to scripts/bootstrap.ps1 so repo-relative values for MODELS_DIR, EVIDENCE_ROOT, and LOG_FILE are normalised before provisioning directories
- extend the Python and Pester metadata checks to lock in the new bootstrap guarantees and refreshed documentation about the stable minimal stack
- surface the tighter bootstrap behaviour in README.md and add a status snapshot table to docs/STATE_VERIFICATION.md for quick oversight of what is stable versus host-dependent

## Testing
- pytest
- pwsh -File tests/pester/scripts.Tests.ps1 *(fails: pwsh not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc78d2c024832c8a42146b3ac380e7