### PR TITLE
Fix Pester test helper scoping

### DIFF
--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -2,27 +2,27 @@ if (-not $PSScriptRoot) {
     throw "PSScriptRoot was not populated; unable to determine repository root."
 }
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$script:repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 
-if (-not $repoRoot) {
+if (-not $script:repoRoot) {
     throw "Unable to resolve repository root from PSScriptRoot: $PSScriptRoot"
 }
 
-if (-not (Test-Path -Path $repoRoot -PathType Container)) {
-    throw "Resolved repository root does not exist: $repoRoot"
+if (-not (Test-Path -Path $script:repoRoot -PathType Container)) {
+    throw "Resolved repository root does not exist: $script:repoRoot"
 }
 
-function Get-RequiredFileContent {
+function script:Get-RequiredFileContent {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string] $RelativePath
     )
 
-    $fullPath = Join-Path -Path $repoRoot -ChildPath $RelativePath
+    $fullPath = Join-Path -Path $script:repoRoot -ChildPath $RelativePath
 
     if (-not $fullPath) {
-        throw "Failed to build a path for '$RelativePath' from repository root '$repoRoot'."
+        throw "Failed to build a path for '$RelativePath' from repository root '$($script:repoRoot)'."
     }
 
     if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
@@ -79,10 +79,8 @@ Describe 'scripts/bootstrap.ps1' {
 
 Describe 'context evaluation tooling' {
     BeforeAll {
-        $script:sweepPath = Join-Path -Path $repoRoot -ChildPath 'scripts/context-sweep.ps1'
-        $script:sweepContent = Get-Content -Path $script:sweepPath -Raw
-        $script:evalPath = Join-Path -Path $repoRoot -ChildPath 'scripts/eval-context.ps1'
-        $script:evalContent = Get-Content -Path $script:evalPath -Raw
+        $script:sweepContent = Get-RequiredFileContent -RelativePath 'scripts/context-sweep.ps1'
+        $script:evalContent = Get-RequiredFileContent -RelativePath 'scripts/eval-context.ps1'
     }
 
     It 'context sweep exposes built-in profiles' {
@@ -100,8 +98,7 @@ Describe 'context evaluation tooling' {
 
 Describe 'scripts/clean/prune_evidence.ps1' {
     BeforeAll {
-        $script:prunePath = Join-Path -Path $repoRoot -ChildPath 'scripts/clean/prune_evidence.ps1'
-        $script:pruneContent = Get-Content -Path $script:prunePath -Raw
+        $script:pruneContent = Get-RequiredFileContent -RelativePath 'scripts/clean/prune_evidence.ps1'
     }
 
     It 'defines Keep parameter with default of 5' {


### PR DESCRIPTION
## Summary
- ensure the repository root helper lives in script scope for the Pester suite
- load context-evaluation and pruning fixtures through the helper so Pester module scopes never see a null repo root
- improve error messaging to reference the script-scoped repository root

## Testing
- Attempted: `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/pester"` *(fails: `pwsh` not available in container)*
- Attempted: `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path tests/pester/scripts.Tests.ps1"` *(fails: `pwsh` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8fa23394832cbe32f2e35fcf4399