### PR TITLE
feat: codify multi-host architecture overlays

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ OLLAMA_PORT=11434
 
 # Paths (relative to the repository root)
 MODELS_DIR=./models
+OPENWEBUI_CONFIG_DIR=./openwebui-data
+SD_WEBUI_MODELS_DIR=./models/stable-diffusion
+SD_WEBUI_CONFIG_DIR=./configs/stable-diffusion
 
 # API integration
 OLLAMA_API_KEY=ollama-local
@@ -19,3 +22,14 @@ EVIDENCE_ROOT=./docs/evidence
 
 # Logging
 LOG_FILE=./logs/stack.log
+
+# Open WebUI overlay
+OPENWEBUI_IMAGE=ghcr.io/open-webui/open-webui:main
+OPENWEBUI_PORT=3000
+OPENWEBUI_OLLAMA_URL=http://ollama:11434
+OPENWEBUI_SECRET_KEY=changeme
+
+# Automatic1111 DirectML overlay
+SD_WEBUI_IMAGE=
+SD_WEBUI_PORT=7860
+SD_WEBUI_COMMANDLINE_ARGS=--use-directml --medvram

--- a/README.md
+++ b/README.md
@@ -13,15 +13,24 @@ This repository ships a minimal Docker Compose stack for running a single Ollama
 2. **Review `.env`** – adjust `OLLAMA_IMAGE`, `OLLAMA_PORT`, or `MODELS_DIR` as required. The compose helper resolves relative paths against the repository root automatically.
 3. **Start the stack** – `./scripts/compose.ps1 up` brings up the Ollama service using the repository `.env`. Add overlays with `-File` when experimenting:
    ```powershell
+   # NVIDIA-enabled host (WSL2/Windows)
    ./scripts/compose.ps1 up -File docker-compose.gpu.yml
+
+   # Host with Open WebUI alongside Ollama
+   ./scripts/compose.ps1 up -File docker-compose.openwebui.yml
+
+   # Host running Automatic1111 with DirectML (requires SD_WEBUI_IMAGE in .env)
+   ./scripts/compose.ps1 up -File docker-compose.automatic1111.directml.yml
    ```
-   Use `down`, `restart`, or `logs` for the other lifecycle operations.
+   Use `down`, `restart`, or `logs` for the other lifecycle operations. Pass `-Context` to target a remote Docker context when coordinating multiple hosts.
 4. **Interact with Ollama** – the API is available at `http://localhost:11434` by default. Use `./scripts/model.ps1` to list, pull, or create models inside the container.
 
 ## Configuration
 - `.env` controls the runtime image (`OLLAMA_IMAGE`), listening port (`OLLAMA_PORT`), storage paths, and diagnostics defaults. If the file is missing the compose helper falls back to `.env.example` but exits early when neither exists so CI can flag the configuration error.
 - `infra/compose/docker-compose.yml` defines the single-service baseline. Images are intentionally unpinned and can be overridden via environment variables to keep deployments modular.
 - `infra/compose/docker-compose.gpu.yml` adds GPU scheduling hints for the Ollama container; layer it only on hosts with CUDA-capable hardware.
+- `infra/compose/docker-compose.openwebui.yml` launches Open WebUI against the running Ollama API to provide a browser frontend.
+- `infra/compose/docker-compose.automatic1111.directml.yml` introduces an Automatic1111 Stable Diffusion container prepared for DirectML acceleration on AMD GPUs. Set `SD_WEBUI_IMAGE` in `.env` to a DirectML-compatible build before using the overlay.
 - `modelfiles/baseline.Modelfile` is the curated default. Extend the folder with additional Modelfiles when experimenting with alternative prompts or parameters.
 
 ## Services
@@ -46,3 +55,5 @@ Two GitHub Actions workflows keep the stack reproducible:
 - Keep tests under `tests/` mirrored with their implementation counterparts to stay aligned with the repository structure described in `AGENTS.md`.
 
 For a quick situational overview, start with `docs/STATE_VERIFICATION.md` and the latest entries under `docs/evidence/`.
+
+Architectural decisions, host roles, and overlay responsibilities are captured in `docs/ARCHITECTURE.md`.

--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,4 @@
 - [ ] Extend the pytest suite with a smoke test that exercises `docker-compose.gpu.yml` once GPU runners are available.
 - [ ] Automate evidence pruning so `docs/evidence/` retains only the latest verification artefacts.
 - [ ] Capture a reference host report after running the trimmed context sweep to provide reviewers with a fresh baseline.
+- [ ] Create a helper script or bootstrap step that seeds Docker contexts for host1/host2 so multi-host orchestration is one command away.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# Multi-Host Architecture Overview
+
+This document captures how the repository maps to the two-host deployment pattern discussed in the WSL2/Docker evaluation. It shows which overlays each host consumes, how shared assets flow between them, and where Docker contexts come into play.
+
+## Goals
+- Keep the **baseline Ollama stack** identical on every platform.
+- Layer **optional services** (GPU, Open WebUI, Automatic1111) as compose overlays so hosts only run what they need.
+- Manage **multiple Docker daemons** from one workstation via Docker contexts.
+
+## Host Roles & Overlay Matrix
+| Host | Purpose | Hardware | Required Compose files | Notes |
+| --- | --- | --- | --- | --- |
+| Host 1 – Windows 11 with WSL2 | Primary development box with NVIDIA GPU | RTX 2060 / 3060 | `docker-compose.yml`, `docker-compose.gpu.yml`, optional `docker-compose.openwebui.yml` | WSL2 backend enables NVIDIA passthrough for Ollama and Open WebUI.|
+| Host 2 – Windows 11 (native) | Stable Diffusion experiments on AMD | Radeon RX6700XT | `docker-compose.yml`, optional `docker-compose.automatic1111.directml.yml` | Requires DirectML-ready Automatic1111 image; Ollama can stay CPU-only.|
+
+Shared assets (Modelfiles, scripts, evidence) live in the repository and sync across hosts via Git. `.env` values are tuned per host after running `./scripts/bootstrap.ps1`.
+
+## Overlay Responsibilities
+- **`docker-compose.gpu.yml`** – switches the Ollama container to GPU mode on supported NVIDIA hosts.
+- **`docker-compose.openwebui.yml`** – adds the Open WebUI frontend and forwards requests to the Ollama API on the Docker network.
+- **`docker-compose.automatic1111.directml.yml`** – provisions an Automatic1111 container with DirectML flags and bind mounts for models/configs. Set `SD_WEBUI_IMAGE` in `.env` to a DirectML-compatible build before starting the overlay.
+
+Each overlay stays optional. Combine them with the baseline manifest as needed:
+```powershell
+# Host 1 – GPU + Open WebUI
+./scripts/compose.ps1 up -File docker-compose.gpu.yml -File docker-compose.openwebui.yml
+
+# Host 2 – Automatic1111 (DirectML) only
+./scripts/compose.ps1 up -File docker-compose.automatic1111.directml.yml
+```
+
+## Docker Context Strategy
+Manage both hosts from a single shell by creating named contexts:
+```powershell
+# Configure once per remote host
+docker context create host1 --docker "host=ssh://user@host1"
+docker context create host2 --docker "host=ssh://user@host2"
+
+# Target a specific host via compose helper
+./scripts/compose.ps1 up -Context host1 -File docker-compose.gpu.yml
+./scripts/compose.ps1 up -Context host2 -File docker-compose.automatic1111.directml.yml
+```
+`-Context` is optional; omit it to operate on the local Docker daemon.
+
+## Current Architecture Sketch
+```
+                   SSH / Docker Context Switch
+        ┌──────────────────────────────────────────┐
+        │                                          │
+┌───────┴────────┐                        ┌────────┴───────┐
+│ Host 1: Win11   │                        │ Host 2: Win11  │
+│ + WSL2 backend  │                        │ (native)       │
+│ - compose.ps1   │                        │ - compose.ps1  │
+│   + gpu.yml     │                        │   + automatic1111 overlay│
+│   + openwebui   │                        │                │
+│ - NVIDIA GPU    │                        │ - AMD + DirectML│
+│ - Ollama + UI   │                        │ - Automatic1111 │
+└────────┬────────┘                        └────────┬───────┘
+         │      Shared repository (Git, Modelfiles, evidence)
+         └───────────────────────────────────────────┘
+```
+
+## Next Steps
+- Ship automated smoke tests for the new overlays once GPU/DirectML runners are available.
+- Provide host-specific bootstrap presets (PowerShell profiles) to speed up `.env` tuning per workstation.

--- a/docs/STATE_VERIFICATION.md
+++ b/docs/STATE_VERIFICATION.md
@@ -10,6 +10,8 @@ This checklist highlights the current stability of the minimal stack and the che
 
 ## Experimental or Host-Dependent
 - **GPU overlay** – `infra/compose/docker-compose.gpu.yml` depends on NVIDIA container support. Treat failures as host-specific until validated on real hardware.
+- **Open WebUI overlay** – `infra/compose/docker-compose.openwebui.yml` couples a UI container to the Ollama API. It expects Ollama to stay reachable on the same Docker network (default bridge) and inherits GPU behaviour from the host.
+- **Automatic1111 DirectML overlay** – `infra/compose/docker-compose.automatic1111.directml.yml` targets AMD GPUs via DirectML. Set `SD_WEBUI_IMAGE` to a compatible image and validate locally before promoting changes.
 - **Context sweeps** – `./scripts/context-sweep.ps1` supports plan-only runs in CI. Full executions still require local model downloads and sufficient CPU/GPU capacity.
 - **Additional services** – any service layered on top of the minimal stack must ship its own verification steps.
 
@@ -32,7 +34,7 @@ Start it alongside the baseline only when required:
 ./scripts/compose.ps1 up -File docker-compose.qdrant.yml
 ```
 
-Ship complementary guardrails (pytest or Pester checks) with any new overlay so CI can detect drift early.
+Ship complementary guardrails (pytest or Pester checks) with any new overlay so CI can detect drift early. `tests/infra/test_docker_compose.py` now validates the Ollama, Open WebUI, and Automatic1111 overlays at parse time.
 
 ## Verification Steps
 Run these checks after changing infrastructure, scripts, or documentation referenced by the stack:

--- a/infra/compose/docker-compose.automatic1111.directml.yml
+++ b/infra/compose/docker-compose.automatic1111.directml.yml
@@ -1,0 +1,11 @@
+services:
+  stable-diffusion:
+    image: ${SD_WEBUI_IMAGE:?Set SD_WEBUI_IMAGE in .env to a DirectML-compatible Automatic1111 build}
+    restart: unless-stopped
+    environment:
+      - COMMANDLINE_ARGS=${SD_WEBUI_COMMANDLINE_ARGS:---use-directml --medvram}
+    ports:
+      - "${SD_WEBUI_PORT:-7860}:7860"
+    volumes:
+      - ../../${SD_WEBUI_MODELS_DIR:-models/stable-diffusion}:/data/models
+      - ../../${SD_WEBUI_CONFIG_DIR:-configs/stable-diffusion}:/data/config

--- a/infra/compose/docker-compose.openwebui.yml
+++ b/infra/compose/docker-compose.openwebui.yml
@@ -1,0 +1,13 @@
+services:
+  openwebui:
+    image: ${OPENWEBUI_IMAGE:-ghcr.io/open-webui/open-webui:main}
+    restart: unless-stopped
+    depends_on:
+      - ollama
+    environment:
+      - OLLAMA_BASE_URL=${OPENWEBUI_OLLAMA_URL:-http://ollama:11434}
+      - WEBUI_SECRET_KEY=${OPENWEBUI_SECRET_KEY:-changeme}
+    ports:
+      - "${OPENWEBUI_PORT:-3000}:8080"
+    volumes:
+      - ../../${OPENWEBUI_CONFIG_DIR:-openwebui-data}:/app/backend/data

--- a/scripts/compose.ps1
+++ b/scripts/compose.ps1
@@ -1,7 +1,8 @@
 param(
     [ValidateSet('up','down','restart','logs')]
     [string]$Action = 'up',
-    [string[]]$File = @()
+    [string[]]$File = @(),
+    [string]$Context
 )
 
 $ErrorActionPreference = 'Stop'
@@ -47,7 +48,13 @@ $exitCode = 0
 
 Push-Location $repoRoot
 try {
-    $composeArgs = @('compose', '--env-file', $envFile, '-f', $composeFile)
+    $composeArgs = @('compose')
+
+    if ($Context) {
+        $composeArgs += @('--context', $Context)
+    }
+
+    $composeArgs += @('--env-file', $envFile, '-f', $composeFile)
 
     foreach ($overlay in $File) {
         $resolved = Resolve-ComposePath -Path $overlay

--- a/tests/config/test_env_example.py
+++ b/tests/config/test_env_example.py
@@ -32,12 +32,22 @@ def test_env_example_contains_expected_keys() -> None:
         "OLLAMA_IMAGE",
         "OLLAMA_PORT",
         "MODELS_DIR",
+        "OPENWEBUI_CONFIG_DIR",
+        "SD_WEBUI_MODELS_DIR",
+        "SD_WEBUI_CONFIG_DIR",
         "OLLAMA_API_KEY",
         "OLLAMA_BASE_URL",
         "OLLAMA_BENCH_MODEL",
         "OLLAMA_BENCH_PROMPT",
         "EVIDENCE_ROOT",
         "LOG_FILE",
+        "OPENWEBUI_IMAGE",
+        "OPENWEBUI_PORT",
+        "OPENWEBUI_OLLAMA_URL",
+        "OPENWEBUI_SECRET_KEY",
+        "SD_WEBUI_IMAGE",
+        "SD_WEBUI_PORT",
+        "SD_WEBUI_COMMANDLINE_ARGS",
     }
     missing = expected_keys.difference(env)
     assert not missing, f".env.example is missing keys: {sorted(missing)}"
@@ -60,6 +70,18 @@ def test_prompt_reference_exists() -> None:
 
 def test_relative_directories_are_not_absolute() -> None:
     env = load_env()
-    for key in ("MODELS_DIR", "EVIDENCE_ROOT", "LOG_FILE"):
+    for key in (
+        "MODELS_DIR",
+        "OPENWEBUI_CONFIG_DIR",
+        "SD_WEBUI_MODELS_DIR",
+        "SD_WEBUI_CONFIG_DIR",
+        "EVIDENCE_ROOT",
+        "LOG_FILE",
+    ):
         value = env[key]
         assert value.startswith("."), f"{key} should use a repository-relative path"
+
+
+def test_sd_webui_image_requires_manual_selection() -> None:
+    env = load_env()
+    assert env["SD_WEBUI_IMAGE"] == "", "SD_WEBUI_IMAGE should default to empty so the user selects a DirectML image"

--- a/tests/pester/scripts.Tests.ps1
+++ b/tests/pester/scripts.Tests.ps1
@@ -44,6 +44,8 @@ Describe 'scripts/compose.ps1' {
     It 'bubbles repository env file and overlays to docker compose' {
         ($script:composeContent -match '--env-file') | Should -BeTrue
         ($script:composeContent -match '\[string\[\]\]\$File') | Should -BeTrue
+        ($script:composeContent -match '\[string\]\$Context') | Should -BeTrue
+        ($script:composeContent -match '--context') | Should -BeTrue
     }
 }
 

--- a/tests/test_powershell_metadata.py
+++ b/tests/test_powershell_metadata.py
@@ -21,6 +21,8 @@ def test_compose_script_exposes_expected_actions() -> None:
     assert re.search(r"ValidateSet\('up','down','restart','logs'\)", content)
     assert "--env-file" in content, "compose helper should pass repository env file to docker"
     assert "[string[]]$File" in content, "compose helper should expose overlay parameter"
+    assert "[string]$Context" in content, "compose helper should expose optional Docker context parameter"
+    assert "--context" in content, "compose helper should forward Docker context when provided"
 
 
 def test_bootstrap_supports_prompt_secrets_switch() -> None:


### PR DESCRIPTION
## Summary
- add Open WebUI and Automatic1111 DirectML compose overlays plus sample env overrides
- document the multi-host architecture and host-specific responsibilities
- allow compose helper to target Docker contexts and extend guardrail tests for new overlays

## Testing
- python -m pip install -r requirements/python/dev.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cffc5354c4832c86d9ca2a794ea0ed